### PR TITLE
fix sidebar selector

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,7 +19,7 @@ const participantObserver = new MutationObserver(mutations => {
 const rootObserver = new MutationObserver(mutations => {
     for (const mutation of mutations) {
         if (mutation.type === 'childList') {
-            const sidebar = document.querySelector('.R3Gmyc.qwU8Me:not(.qdulke)')
+            const sidebar = document.querySelector('.R3Gmyc')
             if (sidebar) {
                 if (!isParticipantListObserverSet) {
                     const participantContainer = document.querySelector('[aria-label="Participants"]');


### PR DESCRIPTION
Hi, Jestin,
your extension broke a few months ago – apparently some classes from the sidebar have been removed and the selector that was supposed to match it in the part with mutation observer stopped working. After making it less specific, it works fine and it's just as specific as it needs to be, because only one div on the page matches it.
Please have a look if it works for you. If it does, it would be great if you could release a patch to the Chrome web store.
By the way, thank you for the brilliant idea and implementation of the checklist – it made my life way easier on my daily standup meetings :)